### PR TITLE
Ensure stage weight column is present in base schema

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -29,6 +29,7 @@ CREATE TABLE stages (
     name TEXT NOT NULL,
     description TEXT,
     sort_order INTEGER DEFAULT 0,
+    weight INTEGER DEFAULT 1,
     is_completed BOOLEAN DEFAULT 0,
     FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
     FOREIGN KEY (parent_stage_id) REFERENCES stages (id) ON DELETE CASCADE


### PR DESCRIPTION
## Summary
- add the `weight` column to the base schema for the `stages` table so new databases and in-memory test databases include it by default
- keep schema in sync with migrations to prevent missing-column errors when querying weighted stage progress

## Testing
- npm test --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d427fb202c8329893360f52ae4555d